### PR TITLE
Meldekort-bugfix: Oppdater person-identer

### DIFF
--- a/app/drift/person-identer/oppdater/page.tsx
+++ b/app/drift/person-identer/oppdater/page.tsx
@@ -1,0 +1,14 @@
+import { Page, PageBlock } from '@navikt/ds-react/Page';
+import { OppdaterPersonIdenter } from '../../../../components/drift/person-identer/OppdaterPersonIdenter';
+
+const OppdaterPersonIdenterPage = async () => {
+  return (
+    <Page>
+      <PageBlock width="md">
+        <OppdaterPersonIdenter />
+      </PageBlock>
+    </Page>
+  );
+};
+
+export default OppdaterPersonIdenterPage;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,7 @@ import { Heading, HGrid, VStack } from '@navikt/ds-react';
 import { Page, PageBlock } from '@navikt/ds-react/Page';
 import { appInfo } from 'lib/services/driftService';
 import { LinkCard, LinkCardAnchor, LinkCardIcon, LinkCardTitle } from '@navikt/ds-react/LinkCard';
-import { BackwardIcon, ClockIcon, EnvelopeClosedIcon, MagnifyingGlassIcon, StethoscopeIcon } from '@navikt/aksel-icons';
+import { BackwardIcon, ClockIcon, EnvelopeClosedIcon, MagnifyingGlassIcon, StethoscopeIcon, PersonIcon } from '@navikt/aksel-icons';
 import { FeilendeJobberLinkCard } from 'components/drift/feilendejobber/FeilendeJobberLinkCard';
 
 export default function Home() {
@@ -68,12 +68,22 @@ export default function Home() {
               <LinkCardAnchor href={`/drift/brev/avbryt`}>Avbryt brev i behandlingsflyt</LinkCardAnchor>
             </LinkCardTitle>
           </LinkCard>
+
           <LinkCard size="small">
             <LinkCardIcon>
               <ClockIcon fontSize="2rem" />
             </LinkCardIcon>
             <LinkCardTitle>
               <LinkCardAnchor href={`/drift/rettighetsperiode`}>Utvid rettighetsperiode til Tid.Maks</LinkCardAnchor>
+            </LinkCardTitle>
+          </LinkCard>
+
+          <LinkCard size="small">
+            <LinkCardIcon>
+              <PersonIcon fontSize="2rem" />
+            </LinkCardIcon>
+            <LinkCardTitle>
+              <LinkCardAnchor href={`/drift/person-identer/oppdater`}>Oppdater identer for person i behandlingsflyt og meldekort</LinkCardAnchor>
             </LinkCardTitle>
           </LinkCard>
         </VStack>

--- a/components/drift/person-identer/OppdaterPersonIdenter.tsx
+++ b/components/drift/person-identer/OppdaterPersonIdenter.tsx
@@ -37,7 +37,7 @@ export const OppdaterPersonIdenter = () => {
   return (
     <VStack gap="space-16" marginBlock="space-32">
       <Heading size="medium">
-        Tving behandlingsflyt til å hente nye personidenter fra PDL for person tilkyttet oppgitt saksnummer
+        Tving behandlingsflyt til å hente nye personidenter fra PDL for person tilknyttet oppgitt saksnummer
       </Heading>
       <InfoCard data-color="info">
         <InfoCard.Header>

--- a/components/drift/person-identer/OppdaterPersonIdenter.tsx
+++ b/components/drift/person-identer/OppdaterPersonIdenter.tsx
@@ -1,0 +1,71 @@
+'use client';
+import { useState } from 'react';
+import { BodyShort, Button, Heading, HStack, InfoCard, Textarea, TextField, VStack } from '@navikt/ds-react';
+import { oppdaterPersonIdenter } from '../../../lib/clientApi';
+
+export const OppdaterPersonIdenter = () => {
+  const [saksnummer, setSaksnummer] = useState('');
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [message, setMessage] = useState<string>('');
+
+  const onClick = async () => {
+    setIsLoading(true);
+    setMessage('');
+
+    if (!saksnummer) {
+      setMessage('Saksnummer må fylles ut');
+      setIsLoading(false);
+      return;
+    }
+
+    console.log('oppdater-person-identer', { saksnummer });
+
+    try {
+      const response = await oppdaterPersonIdenter(saksnummer);
+      if (response.ok) {
+        setMessage('ok 👍');
+      } else {
+        setMessage(await response.text());
+      }
+    } catch (err) {
+      console.log(err);
+      setMessage('Noe gikk galt');
+    }
+    setIsLoading(false);
+  };
+
+  return (
+    <VStack gap="space-16" marginBlock="space-32">
+      <Heading size="medium">
+        Tving behandlingsflyt til å hente nye personidenter fra PDL for person tilkyttet oppgitt saksnummer
+      </Heading>
+      <InfoCard data-color="info">
+        <InfoCard.Header>
+          <InfoCard.Title>Person tilknyttet sak får tilført identer fra PDL</InfoCard.Title>
+        </InfoCard.Header>
+        <InfoCard.Content>
+          <p>
+          Denne skal brukes for saker i behandlingsflyt og meldekort hvor bruker har fått ny ident. Eksempel bruker har
+          gått fra d-nummer til f-nummer i folkeregisteret.
+          </p><p>
+          Behandlingsflyt oppdaterer sin database person med nye identer fra PDL og sender denne informasjonen
+          umiddelbart videre til meldekort-backend som også oppdaterer person i egen database tilknyttet sakens
+          meldekortdata.
+          </p><p>
+          Dette er f.eks. nyttig ved feilsituasjoner hvor bruker ikke får tilgang til meldekortene sine
+          da disse er koblet til kun gammel bruker-ident i behandlingsflyt.
+          </p>
+        </InfoCard.Content>
+      </InfoCard>
+      <TextField
+        label="Saksnummer i behandlingsflyt"
+        value={saksnummer}
+        onChange={(e) => setSaksnummer(e.target.value)}
+      />
+      <Button onClick={onClick} loading={isLoading}>
+        Oppdater identer
+      </Button>
+      {message && <BodyShort>{message}</BodyShort>}
+    </VStack>
+  );
+};

--- a/lib/clientApi.ts
+++ b/lib/clientApi.ts
@@ -36,6 +36,12 @@ export function avbrytBrev(bestillingsreferanse: string, begrunnelse: string) {
   });
 }
 
+export function oppdaterPersonIdenter(saksnummer: string) {
+  return fetch(`/api/drift/sak/${saksnummer}/oppdater-person-identer`, {
+    method: 'POST',
+  });
+}
+
 export function hentSakDriftsinfo(saksnummer: string) {
   return fetch(`/api/drift/sak/${saksnummer}/info`, {
     method: 'POST',


### PR DESCRIPTION
Meldekort-bugfix: Legger til manuell trigger for å hente nye identer fra PDL og oppdatere listen over identer tilknyttet en person (og sak) i behandlingsflyt og meldekort-backend.