### PR TITLE
Eksponer paw-patrol på ansatt-ingress i dev

### DIFF
--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -1,3 +1,4 @@
 ingresses:
   - 'https://aap-paw-patrol.intern.dev.nav.no'
+  - 'https://aap-paw-patrol.ansatt.dev.nav.no'
 driftrolle: bc89623f-4624-4978-ac54-acd048c0f2a5


### PR DESCRIPTION
Eksponer paw-patrol på ansatt-ingress i dev slik at ikke-utviklere kan få titte på saker i dev i pawpatrol. (behovet dukket opp for å se den nye siden https://aap-paw-patrol.intern.dev.nav.no/drift/api-intern/)